### PR TITLE
project: allow loading from user-specified filename

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snapcore/spread
 
-go 1.13
+go 1.16
 
 require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -93,9 +93,10 @@ suites:
 		{"spread.yaml", "custom.yaml", "cannot load project: open /.*/custom.yaml: no such file or directory"},
 	} {
 		tmpdir := c.MkDir()
-		os.MkdirAll(filepath.Join(tmpdir, "subdir"), 0755)
+		err := os.MkdirAll(filepath.Join(tmpdir, "subdir"), 0755)
+		c.Assert(err, IsNil)
 
-		err := os.WriteFile(filepath.Join(tmpdir, tc.name), spreadYaml, 0644)
+		err = os.WriteFile(filepath.Join(tmpdir, tc.name), spreadYaml, 0644)
 		c.Assert(err, IsNil)
 		err = os.MkdirAll(filepath.Join(tmpdir, "tests"), 0755)
 		c.Assert(err, IsNil)

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -87,10 +87,14 @@ suites:
 		{".spread.yaml", "", ""},
 		{"other.yaml", "", "cannot load project from .*: cannot find spread.yaml or .spread.yaml"},
 		{"custom.yaml", "custom.yaml", ""},
+		{"subdir/custom.yaml", "subdir/custom.yaml", ""},
+		{"subdir/custom.yaml", "subdir/.././subdir/custom.yaml", ""},
 		{"spread.yaml", "/custom.yaml", "cannot load project: open /custom.yaml: no such file or directory"},
 		{"spread.yaml", "custom.yaml", "cannot load project: open /.*/custom.yaml: no such file or directory"},
 	} {
 		tmpdir := c.MkDir()
+		os.MkdirAll(filepath.Join(tmpdir, "subdir"), 0755)
+
 		err := os.WriteFile(filepath.Join(tmpdir, tc.name), spreadYaml, 0644)
 		c.Assert(err, IsNil)
 		err = os.MkdirAll(filepath.Join(tmpdir, "tests"), 0755)


### PR DESCRIPTION
Allow loading the spread project from a filename specified by the
user using an environment variable. This was chosen over a command
line option to avoid encouraging projects to use arbitrary random
filenames.

If the environment variable is not set, current behavior is kept
and the project will be loaded from `spread.yaml` or `.spread.yaml`
in the current or parent directories. If the variable is set, parent
directories will not be searched.

This is an experimental, undocumented feature and may be removed or
modified without prior notice.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>